### PR TITLE
Provide perspective token in JupyterLab to ensure proper ordering of other extensions

### DIFF
--- a/docs/md/how_to/python/jupyterlab.md
+++ b/docs/md/how_to/python/jupyterlab.md
@@ -59,3 +59,27 @@ Perspective also exposes a JS-only `mimerender-extension`. This lets you view
 this by right clicking one of these files and `Open With->CSVPerspective` (or
 `JSONPerspective` or `ArrowPerspective`). Perspective will also install itself
 as the default handler for opening `.arrow` files. -->
+
+## Depending on Perspective in your own JupyterLab Widget
+
+Perspective provides a [token for integration with JupyterLab's federated dependency model](https://jupyterlab.readthedocs.io/en/stable/extension/extension_dev.html#plugins-interacting-with-each-other).
+This allows your plugin to simply depend on Perspective for initialization.
+
+In your plugin code:
+
+```javascript
+import {IPerspective} from "@finos/perspective-jupyterlab";
+
+export const MyCoolPlugin = {
+  activate,
+  id: "my-cool-plugin",
+  requires: [IPerspective],
+  autoStart: true,
+};
+
+// to use perspective, simply import. No initialization required
+import perspective from "@finos/perspective";
+```
+
+And remember to add `perspective-python` as a python dependency, to ensure
+the Perspective JupyterLab extension is installed.

--- a/packages/perspective-jupyterlab/package.json
+++ b/packages/perspective-jupyterlab/package.json
@@ -31,6 +31,7 @@
         "@jupyter-widgets/base": ">2 <5",
         "@jupyterlab/application": ">2 <5",
         "@lumino/application": "<3",
+        "@lumino/coreutils": "<3",
         "@lumino/widgets": "<3"
     },
     "devDependencies": {

--- a/packages/perspective-jupyterlab/package.json
+++ b/packages/perspective-jupyterlab/package.json
@@ -55,10 +55,6 @@
                 "bundled": true,
                 "singleton": true
             },
-            "@finos/perspective-jupyterlab": {
-                "bundled": true,
-                "singleton": true
-            },
             "@finos/perspective-viewer": {
                 "bundled": true,
                 "singleton": true

--- a/packages/perspective-jupyterlab/package.json
+++ b/packages/perspective-jupyterlab/package.json
@@ -50,6 +50,22 @@
             "@jupyter-widgets/base": {
                 "bundled": false,
                 "singleton": true
+            },
+            "@finos/perspective": {
+                "bundled": true,
+                "singleton": true
+            },
+            "@finos/perspective-viewer": {
+                "bundled": true,
+                "singleton": true
+            },
+            "@finos/perspective-viewer-d3fc": {
+                "bundled": true,
+                "singleton": true
+            },
+            "@finos/perspective-viewer-datagrid": {
+                "bundled": true,
+                "singleton": true
             }
         },
         "discovery": {

--- a/packages/perspective-jupyterlab/package.json
+++ b/packages/perspective-jupyterlab/package.json
@@ -55,6 +55,10 @@
                 "bundled": true,
                 "singleton": true
             },
+            "@finos/perspective-jupyterlab": {
+                "bundled": true,
+                "singleton": true
+            },
             "@finos/perspective-viewer": {
                 "bundled": true,
                 "singleton": true
@@ -64,6 +68,10 @@
                 "singleton": true
             },
             "@finos/perspective-viewer-datagrid": {
+                "bundled": true,
+                "singleton": true
+            },
+            "@finos/perspective-viewer-openlayers": {
                 "bundled": true,
                 "singleton": true
             }

--- a/packages/perspective-jupyterlab/package.json
+++ b/packages/perspective-jupyterlab/package.json
@@ -20,14 +20,15 @@
         "build": "node ./build.mjs",
         "clean": "node ./clean.mjs",
         "test:jupyter": "__JUPYTERLAB_PORT__=6538 npx playwright test --config ../../tools/perspective-test/playwright.config.ts -- --jupyter",
-        "test:jupyter:build": "node ./build.mjs --test"
+        "test:jupyter:build": "node ./build.mjs --test",
+        "test:jupyter:extension": "jupyter labextension build test/extension"
     },
     "dependencies": {
+        "@finos/perspective": "workspace:",
+        "@finos/perspective-viewer": "workspace:",
         "@finos/perspective-viewer-d3fc": "workspace:",
         "@finos/perspective-viewer-datagrid": "workspace:",
         "@finos/perspective-viewer-openlayers": "workspace:",
-        "@finos/perspective-viewer": "workspace:",
-        "@finos/perspective": "workspace:",
         "@jupyter-widgets/base": ">2 <5",
         "@jupyterlab/application": ">2 <5",
         "@lumino/application": "<3",
@@ -40,6 +41,7 @@
         "@jupyterlab/builder": "^4",
         "@prospective.co/procss": "^0.1.16",
         "copy-webpack-plugin": "~12",
+        "webpack": "catalog:",
         "zx": "^8.1.8"
     },
     "jupyterlab": {

--- a/packages/perspective-jupyterlab/src/js/index.js
+++ b/packages/perspective-jupyterlab/src/js/index.js
@@ -22,6 +22,7 @@ await Promise.all([
 ]);
 
 export * from "./model";
+export { IPerspective } from "./plugin";
 export * from "./version";
 export * from "./view";
 export * from "./widget";

--- a/packages/perspective-jupyterlab/src/js/plugin.js
+++ b/packages/perspective-jupyterlab/src/js/plugin.js
@@ -11,12 +11,18 @@
 // ┗━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━┛
 
 import { IJupyterWidgetRegistry } from "@jupyter-widgets/base";
-import { Token } from "@lumino/coreutils";
 import { PerspectiveModel } from "./model";
+import {
+    IPerspective,
+    IPerspectiveJupyterlab,
+    IPerspectiveViewer,
+    IPerspectiveViewerD3fc,
+    IPerspectiveViewerDatagrid,
+    IPerspectiveViewerOpenlayers,
+} from "./tokens";
 import { PerspectiveView } from "./view";
 import { PERSPECTIVE_VERSION } from "./version";
 const EXTENSION_ID = "@finos/perspective-jupyterlab";
-export const IPerspective = new Token(EXTENSION_ID);
 
 /**
  * PerspectiveJupyterPlugin Defines the Jupyterlab plugin, and registers `PerspectiveModel` and `PerspectiveView`
@@ -26,7 +32,14 @@ export const PerspectiveJupyterPlugin = {
     id: EXTENSION_ID,
     // @ts-ignore
     requires: [IJupyterWidgetRegistry],
-    provides: [IPerspective],
+    provides: [
+        IPerspective,
+        IPerspectiveJupyterlab,
+        IPerspectiveViewer,
+        IPerspectiveViewerD3fc,
+        IPerspectiveViewerDatagrid,
+        IPerspectiveViewerOpenlayers,
+    ],
     activate: (app, registry) => {
         registry.registerWidget({
             name: EXTENSION_ID,

--- a/packages/perspective-jupyterlab/src/js/plugin.js
+++ b/packages/perspective-jupyterlab/src/js/plugin.js
@@ -11,10 +11,12 @@
 // ┗━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━┛
 
 import { IJupyterWidgetRegistry } from "@jupyter-widgets/base";
+import { Token } from "@lumino/coreutils";
 import { PerspectiveModel } from "./model";
 import { PerspectiveView } from "./view";
 import { PERSPECTIVE_VERSION } from "./version";
 const EXTENSION_ID = "@finos/perspective-jupyterlab";
+export const IPerspective = new Token(EXTENSION_ID);
 
 /**
  * PerspectiveJupyterPlugin Defines the Jupyterlab plugin, and registers `PerspectiveModel` and `PerspectiveView`
@@ -24,6 +26,7 @@ export const PerspectiveJupyterPlugin = {
     id: EXTENSION_ID,
     // @ts-ignore
     requires: [IJupyterWidgetRegistry],
+    provides: [IPerspective],
     activate: (app, registry) => {
         registry.registerWidget({
             name: EXTENSION_ID,

--- a/packages/perspective-jupyterlab/src/js/tokens.js
+++ b/packages/perspective-jupyterlab/src/js/tokens.js
@@ -10,36 +10,19 @@
 // ┃ of the [Apache License 2.0](https://www.apache.org/licenses/LICENSE-2.0). ┃
 // ┗━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━┛
 
-import perspective from "@finos/perspective";
-import perspective_viewer from "@finos/perspective-viewer";
+import { Token } from "@lumino/coreutils";
 
-import server_wasm from "@finos/perspective/dist/wasm/perspective-server.wasm";
-import client_wasm from "@finos/perspective-viewer/dist/wasm/perspective-viewer.wasm";
-
-await Promise.all([
-    perspective_viewer.init_client(client_wasm),
-    perspective.init_server(server_wasm),
-]);
-
-export * from "./model";
-export * from "./tokens";
-export * from "./version";
-export * from "./view";
-export * from "./widget";
-
-import "@finos/perspective-viewer-datagrid";
-import "@finos/perspective-viewer-d3fc";
-import "@finos/perspective-viewer-openlayers";
-
-// NOTE: only expose the widget here
-import { PerspectiveJupyterPlugin } from "./plugin";
-
-let plugins = [PerspectiveJupyterPlugin];
-
-// Conditionally import renderers if running in jupyterlab only
-if (window && window._JUPYTERLAB) {
-    const { PerspectiveRenderers } = await import("./renderer");
-    plugins.push(PerspectiveRenderers);
-}
-
-export default plugins;
+export const IPerspective = new Token("@finos/perspective");
+export const IPerspectiveJupyterlab = new Token(
+    "@finos/perspective-jupyterlab",
+);
+export const IPerspectiveViewer = new Token("@finos/perspective-viewer");
+export const IPerspectiveViewerD3fc = new Token(
+    "@finos/perspective-viewer-d3fc",
+);
+export const IPerspectiveViewerDatagrid = new Token(
+    "@finos/perspective-viewer-datagrid",
+);
+export const IPerspectiveViewerOpenlayers = new Token(
+    "@finos/perspective-viewer-openlayers",
+);

--- a/packages/perspective-jupyterlab/test/jupyter/extension/extension.js
+++ b/packages/perspective-jupyterlab/test/jupyter/extension/extension.js
@@ -10,37 +10,13 @@
 // ┃ of the [Apache License 2.0](https://www.apache.org/licenses/LICENSE-2.0). ┃
 // ┗━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━┛
 
-const CopyPlugin = require("copy-webpack-plugin");
-const webpack = require("webpack");
-const { ModuleFederationPlugin } = webpack.container;
-const packageData = require("./package.json");
+import { IPerspective } from "@finos/perspective-jupyterlab";
 
-const shared = Object.keys(packageData.jupyterlab.sharedPackages)
-    .filter((pkg) => pkg.startsWith("@finos/perspective"))
-    .reduce((obj, pkg) => {
-        obj[pkg] = {
-            singleton: true,
-            packageName: pkg,
-            requiredVersion: require(`${pkg}/package.json`).version,
-        };
-        return obj;
-    }, {});
-
-module.exports = {
-    experiments: {
-        topLevelAwait: true,
+module.exports = [
+    {
+        id: "@finos/perspective-test-federated",
+        autoStart: true,
+        requires: [IPerspective],
+        activate: () => "hello",
     },
-    plugins: [
-        new CopyPlugin({
-            patterns: [{ from: "./install.json", to: "../install.json" }],
-        }),
-        new ModuleFederationPlugin({
-            library: {
-                type: "var",
-                name: ["PERSPECTIVE"],
-            },
-            name: "PERSPECTIVE",
-            shared,
-        }),
-    ],
-};
+];

--- a/packages/perspective-jupyterlab/test/jupyter/extension/package.json
+++ b/packages/perspective-jupyterlab/test/jupyter/extension/package.json
@@ -1,0 +1,41 @@
+{
+    "name": "@finos/perspective-test-federated",
+    "version": "0.0.0",
+    "private": true,
+    "scripts": {},
+    "dependencies": {
+        "@finos/perspective-jupyterlab": "file:../../.."
+    },
+    "devDependencies": {
+        "@jupyterlab/builder": "^4"
+    },
+    "publishConfig": {
+        "access": "public"
+    },
+    "jupyterlab": {
+        "extension": true,
+        "outputDir": "./dist",
+        "sharedPackages": {
+            "@finos/perspective": {
+                "bundled": false,
+                "singleton": true
+            },
+            "@finos/perspective-viewer": {
+                "bundled": false,
+                "singleton": true
+            },
+            "@finos/perspective-viewer-d3fc": {
+                "bundled": false,
+                "singleton": true
+            },
+            "@finos/perspective-viewer-datagrid": {
+                "bundled": false,
+                "singleton": true
+            },
+            "@finos/perspective-viewer-openlayers": {
+                "bundled": false,
+                "singleton": true
+            }
+        }
+    }
+}

--- a/packages/perspective-jupyterlab/webpack.config.js
+++ b/packages/perspective-jupyterlab/webpack.config.js
@@ -11,6 +11,8 @@
 // ┗━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━┛
 
 const CopyPlugin = require("copy-webpack-plugin");
+const { ModuleFederationPlugin } = webpack.container;
+const packageData = require("./package.json");
 
 module.exports = {
     experiments: {
@@ -19,6 +21,19 @@ module.exports = {
     plugins: [
         new CopyPlugin({
             patterns: [{ from: "./install.json", to: "../install.json" }],
+        }),
+        new ModuleFederationPlugin({
+            library: {
+                type: "var",
+                name: ["PERSPECTIVE"],
+            },
+            name: "PERSPECTIVE",
+            shared: packageData.jupyterlab.sharedPackages
+                .filter((pkg) => pkg.startsWith("@finos/perspective"))
+                .reduce((obj, pkg) => {
+                    obj[pkg] = { singleton: true };
+                    return obj;
+                }, {}),
         }),
     ],
 };

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -614,6 +614,9 @@ importers:
       '@lumino/application':
         specifier: <3
         version: 2.4.4
+      '@lumino/coreutils':
+        specifier: <3
+        version: 2.2.1
       '@lumino/widgets':
         specifier: <3
         version: 2.7.1

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -175,7 +175,7 @@ catalogs:
       specifier: '>=6 <7'
       version: 6.3.6
     webpack:
-      specifier: '>=5 <6'
+      specifier: 5.102.0
       version: 5.102.0
     webpack-cli:
       specifier: '>=5 <6'
@@ -635,7 +635,10 @@ importers:
         version: 0.1.17
       copy-webpack-plugin:
         specifier: ~12
-        version: 12.0.2(webpack@5.102.0(webpack-cli@5.1.4))
+        version: 12.0.2(webpack@5.102.0)
+      webpack:
+        specifier: 'catalog:'
+        version: 5.102.0(webpack-cli@5.1.4)
       zx:
         specifier: ^8.1.8
         version: 8.8.4
@@ -12998,17 +13001,17 @@ snapshots:
       '@webassemblyjs/ast': 1.14.1
       '@xtuc/long': 4.2.2
 
-  '@webpack-cli/configtest@2.1.1(webpack-cli@5.1.4(webpack@5.102.0))(webpack@5.102.0)':
+  '@webpack-cli/configtest@2.1.1(webpack-cli@5.1.4)(webpack@5.102.0)':
     dependencies:
       webpack: 5.102.0(webpack-cli@5.1.4)
       webpack-cli: 5.1.4(webpack@5.102.0)
 
-  '@webpack-cli/info@2.0.2(webpack-cli@5.1.4(webpack@5.102.0))(webpack@5.102.0)':
+  '@webpack-cli/info@2.0.2(webpack-cli@5.1.4)(webpack@5.102.0)':
     dependencies:
       webpack: 5.102.0(webpack-cli@5.1.4)
       webpack-cli: 5.1.4(webpack@5.102.0)
 
-  '@webpack-cli/serve@2.0.5(webpack-cli@5.1.4(webpack@5.102.0))(webpack@5.102.0)':
+  '@webpack-cli/serve@2.0.5(webpack-cli@5.1.4)(webpack@5.102.0)':
     dependencies:
       webpack: 5.102.0(webpack-cli@5.1.4)
       webpack-cli: 5.1.4(webpack@5.102.0)
@@ -13723,7 +13726,7 @@ snapshots:
       serialize-javascript: 6.0.2
       webpack: 5.102.0(webpack-cli@5.1.4)
 
-  copy-webpack-plugin@12.0.2(webpack@5.102.0(webpack-cli@5.1.4)):
+  copy-webpack-plugin@12.0.2(webpack@5.102.0):
     dependencies:
       fast-glob: 3.3.3
       glob-parent: 6.0.2
@@ -18683,9 +18686,9 @@ snapshots:
   webpack-cli@5.1.4(webpack@5.102.0):
     dependencies:
       '@discoveryjs/json-ext': 0.5.7
-      '@webpack-cli/configtest': 2.1.1(webpack-cli@5.1.4(webpack@5.102.0))(webpack@5.102.0)
-      '@webpack-cli/info': 2.0.2(webpack-cli@5.1.4(webpack@5.102.0))(webpack@5.102.0)
-      '@webpack-cli/serve': 2.0.5(webpack-cli@5.1.4(webpack@5.102.0))(webpack@5.102.0)
+      '@webpack-cli/configtest': 2.1.1(webpack-cli@5.1.4)(webpack@5.102.0)
+      '@webpack-cli/info': 2.0.2(webpack-cli@5.1.4)(webpack@5.102.0)
+      '@webpack-cli/serve': 2.0.5(webpack-cli@5.1.4)(webpack@5.102.0)
       colorette: 2.0.20
       commander: 10.0.1
       cross-spawn: 7.0.6

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -1,97 +1,94 @@
 packages:
-    - "tools/perspective-test"
-    - "tools/perspective-scripts"
-    - "tools/perspective-bench"
-    - "packages/perspective-client"
-    - "tools/perspective-esbuild-plugin"
-    - "packages/perspective-viewer-datagrid"
-    - "packages/perspective-viewer-d3fc"
-    - "packages/perspective-viewer-openlayers"
-    - "packages/perspective-workspace"
-    - "packages/perspective-jupyterlab"
-    - "packages/perspective-react"
-    - "packages/perspective-cli"
-    - "rust/generate-metadata"
-    - "rust/perspective"
-    - "rust/perspective-js"
-    - "rust/perspective-viewer"
-    - "rust/perspective-python"
-    - "rust/perspective-server"
-    - "examples/*"
-    - "docs"
+  - tools/perspective-test
+  - tools/perspective-scripts
+  - tools/perspective-bench
+  - packages/perspective-client
+  - tools/perspective-esbuild-plugin
+  - packages/perspective-viewer-datagrid
+  - packages/perspective-viewer-d3fc
+  - packages/perspective-viewer-openlayers
+  - packages/perspective-workspace
+  - packages/perspective-jupyterlab
+  - packages/perspective-react
+  - packages/perspective-cli
+  - rust/generate-metadata
+  - rust/perspective
+  - rust/perspective-js
+  - rust/perspective-viewer
+  - rust/perspective-python
+  - rust/perspective-server
+  - examples/*
+  - docs
 
 catalog:
-    # Dependencies
-    "@d3fc/d3fc-chart": "5.1.9"
-    "@d3fc/d3fc-element": "6.2.0"
-    "@jupyter-widgets/base": ">2 <5"
-    "@jupyterlab/application": ">2 <5"
-    "@lumino/application": "<3"
-    "@lumino/widgets": "<3"
-    "chroma-js": ">=3 <4"
-    "d3-array": ">=3"
-    "d3-color": ">=3.1"
-    "d3-selection": ">=3"
-    "d3-svg-legend": ">=2"
-    "d3": "^7.9.0"
-    "d3fc": "^15.2.13"
-    "ol": "^5.3.2"
-    "pro_self_extracting_wasm": "0.0.9"
-    "react-dom": "^18"
-    "react": "^18"
-    "regular-table": "=0.6.8"
-    "stoppable": "=1.1.0"
-    "ws": "^8.17.0"
-
-    # Dev Dependencies
-    "@fontsource/roboto-mono": "4.5.10"
-    "@iarna/toml": "3.0.0"
-    "@jupyterlab/builder": "^4"
-    "@playwright/experimental-ct-react": "=1.52.0"
-    "@playwright/test": "=1.52.0"
-    "@prospective.co/procss": "0.1.17"
-    "@types/d3": "^7.4.3"
-    "@types/lodash": "^4.17.20"
-    "@types/node": ">=22"
-    "@types/react-dom": "^18"
-    "@types/react": "^18"
-    "@types/stoppable": ">=1"
-    "@types/ws": ">=8"
-    "@zip.js/zip.js": "^2.7.54"
-    "apache-arrow": "18.1.0"
-    "arraybuffer-loader": ">=1.0.8 <2"
-    "auto-changelog": "^2.5.0"
-    "chalk": ">=5"
-    "commander": ">=14 <15"
-    "copy-webpack-plugin": "~12"
-    "css-loader": ">=7 <8"
-    "dotenv": ">=17"
-    "esbuild": "^0.25.5"
-    "express-ws": ">=5 <6"
-    "express": ">=5 <6"
-    "fs-extra": ">=11 <12"
-    "glob-gitignore": "^1.0.15"
-    "gradient-parser": ">=1 <2"
-    "html-webpack-plugin": ">=5 <6"
-    "http-server": "^14.1.1"
-    "husky": ">=9"
-    "inquirer": ">=12 <13"
-    "less": "^4.1.0"
-    "lodash": "^4.17.20"
-    "microtime": ">=3 <4"
-    "mkdirp": "^0.5.6"
-    "moment": "^2.30.1"
-    "npm-run-all": "^4.1.5"
-    "octokit": "^1.8.1"
-    "prettier": ">=3 <4"
-    "puppeteer": ">=24"
-    "style-loader": ">=4 < 5"
-    "superstore-arrow": "3.2.0"
-    "tar": "^7.4.3"
-    "tsx": "^4.20.3"
-    "typedoc": "^0.28.7"
-    "typescript": ">=5 <6"
-    "vite": ">=6 <7"
-    "webpack-cli": ">=5 <6"
-    "webpack": ">=5 <6"
-    "zx": ">=8 <9"
+  '@d3fc/d3fc-chart': 5.1.9
+  '@d3fc/d3fc-element': 6.2.0
+  '@fontsource/roboto-mono': 4.5.10
+  '@iarna/toml': 3.0.0
+  '@jupyter-widgets/base': '>2 <5'
+  '@jupyterlab/application': '>2 <5'
+  '@jupyterlab/builder': ^4
+  '@lumino/application': <3
+  '@lumino/widgets': <3
+  '@playwright/experimental-ct-react': '=1.52.0'
+  '@playwright/test': '=1.52.0'
+  '@prospective.co/procss': 0.1.17
+  '@types/d3': ^7.4.3
+  '@types/lodash': ^4.17.20
+  '@types/node': '>=22'
+  '@types/react': ^18
+  '@types/react-dom': ^18
+  '@types/stoppable': '>=1'
+  '@types/ws': '>=8'
+  '@zip.js/zip.js': ^2.7.54
+  apache-arrow: 18.1.0
+  arraybuffer-loader: '>=1.0.8 <2'
+  auto-changelog: ^2.5.0
+  chalk: '>=5'
+  chroma-js: '>=3 <4'
+  commander: '>=14 <15'
+  copy-webpack-plugin: ~12
+  css-loader: '>=7 <8'
+  d3: ^7.9.0
+  d3-array: '>=3'
+  d3-color: '>=3.1'
+  d3-selection: '>=3'
+  d3-svg-legend: '>=2'
+  d3fc: ^15.2.13
+  dotenv: '>=17'
+  esbuild: ^0.25.5
+  express: '>=5 <6'
+  express-ws: '>=5 <6'
+  fs-extra: '>=11 <12'
+  glob-gitignore: ^1.0.15
+  gradient-parser: '>=1 <2'
+  html-webpack-plugin: '>=5 <6'
+  http-server: ^14.1.1
+  husky: '>=9'
+  inquirer: '>=12 <13'
+  less: ^4.1.0
+  lodash: ^4.17.20
+  microtime: '>=3 <4'
+  mkdirp: ^0.5.6
+  moment: ^2.30.1
+  npm-run-all: ^4.1.5
+  octokit: ^1.8.1
+  ol: ^5.3.2
+  prettier: '>=3 <4'
+  pro_self_extracting_wasm: 0.0.9
+  puppeteer: '>=24'
+  react: ^18
+  react-dom: ^18
+  regular-table: '=0.6.8'
+  stoppable: '=1.1.0'
+  style-loader: '>=4 < 5'
+  superstore-arrow: 3.2.0
+  tar: ^7.4.3
+  tsx: ^4.20.3
+  typedoc: ^0.28.7
+  typescript: '>=5 <6'
+  vite: '>=6 <7'
+  webpack: 5.102.0
+  webpack-cli: '>=5 <6'
+  ws: ^8.17.0
+  zx: '>=8 <9'


### PR DESCRIPTION
JupyterLab has a [mechanism for having plugins depend on other plugins](https://jupyterlab.readthedocs.io/en/stable/extension/extension_dev.html#plugins-interacting-with-each-other).

Since perspective registers custom elements (see #3056), this change lets other Jupyter extensions "depend" on `@finos/perspective-jupyterlab` by doing:

```javascript
import {IPerspective} from "@finos/perspective-jupyterlab";

export const MyCoolPlugin = {
  activate,
  id: "my-cool-plugin",
  requires: [IPerspective],
  autoStart: true,
};
```

This then ensures that `@finos/perspective-jupyterlab` gets activated before `MyCoolPlugin`, ensuring that custom webcomponents and wasm loading occurs. Downstream plugins like `MyCoolPlugin` can then just do:

```javascript
import perspective from "@finos/perspective";
```

without any additional initialization. 

Fixes #3056 

I'm open to adding tests but its just a constant, not sure what the best mechanism for doing so is.
~~We can also add developer docs if we want, happy to write them.~~ done

### Pull Request Checklist

-   [x] Description which clearly states what problems the PR solves.
-   [x] Description contains a link to the Github Issue, and any relevent
        Discussions, this PR applies to.
-   [ ] Include new tests that fail without this PR but passes with it.
-   [x] Include any relevent Documentation changes related to this change.
-   [x] Verify all commits have been _signed_ in accordance with the DCO policy.
-   [x] Reviewed PR commit history to remove unnecessary changes.
-   [x] Make sure your PR passes _build_, _test_ and _lint_ steps _completely_.
